### PR TITLE
Use outline instead of border to keep layout

### DIFF
--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -359,7 +359,7 @@ var inject = function () {
                 '<button style="position: absolute; top: -15px; left: 10px;">+</button>' +
                 '<button style="position: absolute; top: -15px; right: -15px;">x</button>' +
                 '<style>' +
-                  '.ng-scope.bat-selected { border: 1px solid red; } ' +
+                  '.ng-scope.bat-selected { outline: 1px solid red; } ' +
                   '.bat-indent { margin-left: 20px; }' +
                 '</style>' +
               '</div>' +

--- a/js/services/appHighlight.js
+++ b/js/services/appHighlight.js
@@ -6,15 +6,15 @@ angular.module('panelApp').factory('appHighlight', function (appCss) {
   var styles = {
     scopes: {
       selector: '.ng-scope',
-      style: 'border: 1px solid red'
+      style: 'outline: 1px solid red'
     },
     bindings: {
       selector: '.ng-binding',
-      style: 'border: 1px solid blue'
+      style: 'outline: 1px solid blue'
     },
     app: {
       selector: '[ng-app]',
-      style: 'border: 1px solid green'
+      style: 'outline: 1px solid green'
     }
   };
 


### PR DESCRIPTION
- using "border" changes the size of elements and potentially breaks layout
- using "outline" preserves element size