### PR TITLE
Annotate config and decorator to avoid strictDI errors

### DIFF
--- a/js/inject/debug.js
+++ b/js/inject/debug.js
@@ -612,7 +612,7 @@ var inject = function () {
       // ===============
 
       var ng = angular.module('ng');
-      ng.config(function ($provide) {
+      ng.config(['$provide', function ($provide) {
         // methods to patch
 
         // $provide.provider
@@ -709,7 +709,7 @@ var inject = function () {
           };
         });
 
-        $provide.decorator('$rootScope', function ($delegate) {
+        $provide.decorator('$rootScope', ['$delegate', function ($delegate) {
 
           var watchFnToHumanReadableString = function (fn) {
             if (fn.exp) {
@@ -879,8 +879,8 @@ var inject = function () {
 
 
           return $delegate;
-        });
-      });
+        }]);
+      }]);
     };
 
     // Return a script element with the above code embedded in it


### PR DESCRIPTION
With the introduction of [ng-strict-di](https://docs.angularjs.org/api/ng/directive/ngApp), any apps that enable strict dependency injection break when AngularJS Batarang is enabled, giving the following error:

```
Uncaught Error: [$injector:modulerr] Failed to instantiate module ng due to:
Error: [$injector:strictdi] function($provide) is not using explicit annotation and cannot be invoked in strict mode
http://errors.angularjs.org/1.3.0-beta.11/$injector/st...
```

This issue has been reported previously: #119

To make AngularJS Batarang compatible with strict-di, this PR adds annotations to the two un-annotated functions that are causing the problem.

