### PR TITLE
fix(strictdi): Use strict DI wherever possible

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp');
 var source = require('vinyl-source-stream');
+var ngAnnotate = require('browserify-ngannotate');
 var browserify = require('browserify');
 
 var main = require('./package.json').main;
@@ -9,7 +10,7 @@ gulp.task('watch', function(){
 });
 
 gulp.task('browserify', function() {
-  var bundleStream = browserify('./' + main).bundle().pipe(source(main));
+  var bundleStream = browserify('./' + main).transform(ngAnnotate,{global:true}).bundle().pipe(source(main));
   return bundleStream.pipe(gulp.dest('./dist'));
 });
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "chrome extension for inspecting angular apps",
   "main": "hint.js",
   "devDependencies": {
+    "browserify-ngannotate": "^0.4.0",
     "karma-chrome-launcher": "^0.1.4",
     "karma-jasmine": "^0.1.5"
   },


### PR DESCRIPTION
This change implements annotation through ng-annotate, thus reducing the risk of missing any annotations now or in the future.

Adding the annotations to angularjs-batarang itself does not fully fix the issue, as dependencies of this project also have missing annotations. For example here: https://github.com/angular/angular-hint-controllers/blob/master/hint-controllers.js#L19

Closes #136
Fixes #119
Fixes #138