### PR TITLE
chore(travis): Force Travis to use npm v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 install:
   - mkdir -p $LOGS_DIR
   - ./scripts/sauce_connect_setup.sh
+  - npm install -g npm@2.9.0
   - npm install
   - npm install -g gulp
   - npm install -g karma-cli


### PR DESCRIPTION
Versions before 2 have race conditions that can cause false negatives in our tests