### PR TITLE
Appropriately process messages received via postMessage

### DIFF
--- a/hint.js
+++ b/hint.js
@@ -8,6 +8,7 @@ require('angular-hint');
 
 angular.hint.onAny(function (data, severity) {
   window.postMessage({
+    __fromBatarang: true,
     module: this.event.split(':')[0],
     event: this.event,
     data: data,

--- a/inject.js
+++ b/inject.js
@@ -3,7 +3,7 @@ if (document.cookie.indexOf('__ngDebug=true') != -1) {
 }
 
 function bootstrapHint () {
-  chrome.extension.sendMessage('refresh');
+  chrome.runtime.sendMessage('refresh');
 
   var html = document.getElementsByTagName('html')[0];
 
@@ -12,11 +12,20 @@ function bootstrapHint () {
   script.src = chrome.extension.getURL('dist/hint.js');
 
   window.addEventListener('message', function (evt) {
-    // We only accept messages from ourselves
-    if (event.source !== window) {
-      return;
+    // There's no good way to verify the provenance of the message.
+    // evt.source === window is true for all messages sent from
+    // the main frame. evt.origin is going to be the webpage's origin,
+    // even if the message originated from a chrome:// script you injected.
+
+    // The only thing we can do is see if the message *looks* like something
+    // we would send, cross our fingers, and send it on.
+    // Thus, we check for one of the properties known to be on *all* of our
+    // messages (__fromBatarang === true).
+    var eventData = evt.data;
+    // NOTE: Check for null before checking for the property, since typeof null === 'object'.
+    if (typeof eventData === 'object' && eventData !== null && eventData.hasOwnProperty('__fromBatarang') && eventData.__fromBatarang) {
+      chrome.runtime.sendMessage(eventData);
     }
-    chrome.extension.sendMessage(evt.data);
   });
 
   html.setAttribute('ng-hint', '');

--- a/panel/components/inspected-app/inspected-app.js
+++ b/panel/components/inspected-app/inspected-app.js
@@ -56,7 +56,7 @@ function inspectedAppService($rootScope, $q) {
     chrome.devtools.inspectedWindow.eval('angular.hint.' + method + '(' + args + ')');
   }
 
-  var port = chrome.extension.connect();
+  var port = chrome.runtime.connect();
   port.postMessage(chrome.devtools.inspectedWindow.tabId);
   port.onMessage.addListener(function(msg) {
     $rootScope.$applyAsync(function () {

--- a/panel/components/inspected-app/inspected-app.spec.js
+++ b/panel/components/inspected-app/inspected-app.spec.js
@@ -74,7 +74,7 @@ describe('inspectedApp', function() {
 
   function createMockChrome() {
     return {
-      extension: {
+      runtime: {
         connect: function () {
           return port = createMockSocket();
         }


### PR DESCRIPTION
Chrome extensions are fun, aren't they? :)

* Fixes a typo in `inject.js` (`event` => `evt`)
  * This miraculously worked previously because `window.event` aliases to the last event, and so `event === evt`.
* Use `chrome.runtime` instead of `chrome.extension` for `sendMessage`/`connect`.
  * Those two methods aren't even documented for `chrome.extension`... but it seems they are equivalent (maybe `chrome.extension === chrome.runtime` internally? either way, it's not guaranteed by the docs)
* Fixes `onmessage` filtering to ignore irrelevant messages.
  * `evt.source === window` trivially passes for any messages sent from the `window` context.
    * For example, Facebook.com spams string messages of the form `"setImmediate $0.384240"` at a fast rate as you move your mouse on the page. You were previously sending those on via `sendMessage`.
      * The Batarang didn't see those Facebook messages, though, because `sendMessage` takes an optional string (the target extension ID) as its first parameter. So whenever `chrome.extension.sendMessage` saw one of those `"setImmediate $0.324324"` messages, it would think you were trying to send a message to an extension with that ID!
  * `evt.origin` doesn't work for this, btw, as the origin for your messages will be e.g. `facebook.com` if you open the Batarang on Facebook.

Hope this helps you out. :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angularjs-batarang/222)
<!-- Reviewable:end -->
