### PR TITLE
fix(background.js) destroy child scopes

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,7 +17,7 @@ function bufferOrForward(message, sender) {
   }
 
   if (message !== 'refresh') {
-    setIsHintFlag(message);
+    addMessageHelperProperties(tabId, message);
     bufferData(tabId, message);
   }
   if (devToolsPort) {
@@ -32,7 +32,8 @@ function resetState(tabId) {
   };
 }
 
-function setIsHintFlag(message) {
+function addMessageHelperProperties(tabId, message) {
+  var scopes = data[tabId].scopes;
   var hintables = [
     'Controllers',
     'general',
@@ -40,6 +41,20 @@ function setIsHintFlag(message) {
     'Events'
   ];
   message.isHint = (hintables.indexOf(message.module) > -1);
+
+  if(message.event === 'scope:destroy'){
+    message.data.subTree = getSubTree(scopes, message.data.id);
+  }
+}
+
+function getSubTree(scopes, id){
+  var subTree = [id], scope;
+  for(var i = 0; i < subTree.length; i++) {
+    if(scope = scopes[subTree[i]]) {
+      subTree.push.apply(subTree, scope.children);
+    }
+  }
+  return subTree;
 }
 
 function bufferData(tabId, message) {
@@ -62,9 +77,12 @@ function bufferData(tabId, message) {
   } else if (message.data.id && (scope = tabData.scopes[message.data.id])) {
     if (message.event === 'scope:destroy') {
       if (scope.parent) {
-        scope.parent.children.splice(scope.parent.children.indexOf(child), 1);
+        var parentScope = tabData.scopes[scope.parent];
+        parentScope.children.splice(parentScope.children.indexOf(message.data.id), 1);
       }
-      delete scopes[message.data.id];
+      for(var i = 0; i < message.data.subTree.length; i++){
+        delete tabData.scopes[message.data.subTree[i]];
+      }
     } else if (message.event === 'model:change') {
       scope.models[message.data.path] = (typeof message.data.value === 'undefined') ?
                                             undefined : message.data.value;

--- a/panel/components/inspected-app/inspected-app.js
+++ b/panel/components/inspected-app/inspected-app.js
@@ -92,9 +92,12 @@ function inspectedAppService($rootScope, $q) {
         var scope = scopes[message.data.id];
         if (message.event === 'scope:destroy') {
           if (scope.parent) {
-            scope.parent.children.splice(scope.parent.children.indexOf(child), 1);
+            var parentScope = scopes[scope.parent];
+            parentScope.children.splice(parentScope.children.indexOf(message.data.id), 1);
           }
-          delete scopes[message.data.id];
+          for(var i = 0; i < message.data.subTree.length; i++){
+            delete scopes[message.data.subTree[i]];
+          }
         } else if (message.event === 'model:change') {
           scope.models[message.data.path] = (typeof message.data.value === 'undefined') ?
                                                 undefined : JSON.parse(message.data.value);


### PR DESCRIPTION
This code requires the fix to angular-hint submitted as pull request https://github.com/angular/angular-hint/pull/90 (It is very easy to manually patch the hint.js file in the Batarang project with this fix for testing purposes also.)

Destroyed scopes were not being removed from the scope tree. The background.js and inspectedApp code that handled the scope:destroy message was buggy, referencing undefined variables and also not tracking the descendants of the destroyed scopes. This code fixes both issues. All descendants are now present on the scope:destroy message broadcast throughout Batarang. This reduces code that would need repeated in background.js, inspectedApp and probably in future scope.tree.js to fix https://github.com/angular/angularjs-batarang/blob/master/panel/components/scope-tree/scope-tree.js#L77